### PR TITLE
Improiving onAfterWrite for Moode Log

### DIFF
--- a/src/Model/MoodleLog.php
+++ b/src/Model/MoodleLog.php
@@ -99,14 +99,14 @@ class MoodleLog extends DataObject
         if($this->IsSuccess === false) {
             if((bool) $this->ErrorEmailSent === (bool) false) {
                 $adminEmail = Config::inst()->get(Email::class, 'admin_email');
-                $result = (new Email(
+                (new Email(
                     $adminEmail,
                     $adminEmail,
                     'Moodle Connection Error',
                     'There was an error in connection with Moodle,
                     see: <a href="'.Director::absoluteURL($this->CMSEditLink()).'">'.Director::absoluteURL($this->CMSEditLink()).'</a>'
                 ))->send();
-                $this->ErrorEmailSent =$result;
+                $this->ErrorEmailSent = true;
                 $this->write();
             }
         }

--- a/src/Model/MoodleLog.php
+++ b/src/Model/MoodleLog.php
@@ -99,13 +99,13 @@ class MoodleLog extends DataObject
         if($this->IsSuccess === false) {
             if((bool) $this->ErrorEmailSent === (bool) false) {
                 $adminEmail = Config::inst()->get(Email::class, 'admin_email');
-                (new Email(
+                Email::create(
                     $adminEmail,
                     $adminEmail,
                     'Moodle Connection Error',
                     'There was an error in connection with Moodle,
                     see: <a href="'.Director::absoluteURL($this->CMSEditLink()).'">'.Director::absoluteURL($this->CMSEditLink()).'</a>'
-                ))->send();
+                )->send();
                 $this->ErrorEmailSent = true;
                 $this->write();
             }


### PR DESCRIPTION
Email->send() is a void function now, so $ErrorEmailSent was never being set. This means an infinite loop of sending the error alert email when IsSuccess is false.

This PR sets the variable so the write()->onAfterWrite() pipeline can't keep looping and changes from new Email syntax to Email::create syntax to allow class injection (eg for our email logging).